### PR TITLE
Remove 'log/' from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@
 .DS_Store
 
 # Maven
-log/
 target/
 
 # netbeans


### PR DESCRIPTION
This was causing git to ignore the legitimate java source files in ../com/heartbeat/log/
