### PR TITLE
Add test for Trim() on an empty ByteArray.

### DIFF
--- a/heartbeat-common/src/test/java/com/heartbeat/common/array/ByteArrayTest.java
+++ b/heartbeat-common/src/test/java/com/heartbeat/common/array/ByteArrayTest.java
@@ -16,4 +16,15 @@ public class ByteArrayTest {
         assert trimmed.length == 8;
 
     }
+
+    @Test
+    public void testTrimEmptyArray() throws Exception {
+        byte[] original = {};
+        byte[] trimmed = ByteArray.trim(original);
+        assert trimmed.length == 0;
+
+        byte[] original2 = {0, 0};
+        trimmed = ByteArray.trim(original2);
+        assert trimmed.length == 0;
+    }
 }


### PR DESCRIPTION
With this commit, I hope to increase code coverage for ByteArray.java

The below snippet is currently a partial hit in Codecov

```
public static final byte[] trim(byte[] bytes) {
    int i = bytes.length - 1;
    while (i >= 0 && bytes[i] == 0) {
        --i;
    }
    ...
}
```
